### PR TITLE
Add an option to print arrys colored

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
             <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.diogonunes</groupId>
+            <artifactId>JColor</artifactId>
+            <version>5.0.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/com/github/cbl/algorithm_analyzer/sorts/shellsort/Shellsort.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/sorts/shellsort/Shellsort.java
@@ -8,6 +8,7 @@ import com.github.cbl.algorithm_analyzer.util.ArrayWriter;
 import com.github.cbl.algorithm_analyzer.util.Comparator;
 
 import java.util.StringJoiner;
+import java.util.stream.IntStream;
 
 public class Shellsort<T extends Comparable<T>> implements Algorithm<Event, Shellsort.Data<T>> {
 
@@ -18,7 +19,11 @@ public class Shellsort<T extends Comparable<T>> implements Algorithm<Event, Shel
         @Override
         public String toString() {
             final StringJoiner sj = new StringJoiner("\n");
-            sj.add(ArrayPrinter.toString(array));
+            var colors =
+                    IntStream.range(0, array.length)
+                            .map(i -> i % (int) Math.max(1, stepWidth))
+                            .toArray();
+            sj.add(ArrayPrinter.toString(array, colors));
             sj.add("Comparisons: " + comparisons);
             sj.add("Writes: " + writes);
             sj.add("Stepwidth: " + stepWidth);

--- a/src/main/java/com/github/cbl/algorithm_analyzer/util/ArrayPrinter.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/util/ArrayPrinter.java
@@ -1,11 +1,34 @@
 package com.github.cbl.algorithm_analyzer.util;
 
+import static com.diogonunes.jcolor.Ansi.*;
+import static com.diogonunes.jcolor.Attribute.*;
+
+import com.diogonunes.jcolor.Attribute;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
 /** Utility class for pretty-printing arrays */
 public class ArrayPrinter {
+
+    private static final Attribute[][] COLORS = {
+        {
+            BLACK_TEXT(), BACK_COLOR(196),
+        },
+        {
+            BLACK_TEXT(), BACK_COLOR(82),
+        },
+        {
+            BLACK_TEXT(), BACK_COLOR(226),
+        },
+        {
+            BLACK_TEXT(), BACK_COLOR(208),
+        },
+        {
+            BLACK_TEXT(), BACK_COLOR(165),
+        },
+    };
 
     /**
      * Pretty-formats an array to a 'list of fields' w/ ASCII symbols
@@ -14,12 +37,29 @@ public class ArrayPrinter {
      * @return a string representing the array
      */
     public static String toString(Object[] arr) {
+        return toString(arr, new int[0]);
+    }
+
+    /**
+     * Pretty-formats an array to a 'list of fields' w/ ASCII symbols
+     *
+     * @param arr the array
+     * @param colors colors of values. Shall be in (0,5]
+     * @return a string representing the array
+     */
+    public static String toString(Object[] arr, int[] colors) {
         List<Integer> widths = new ArrayList<>();
+
         final StringJoiner arrSj = new StringJoiner("|", "|", "|");
-        for (Object el : arr) {
+        for (int i = 0; i < arr.length; i++) {
+            Object el = arr[i];
+            var color =
+                    i >= colors.length
+                            ? new Attribute[] {BLACK_TEXT()}
+                            : COLORS[colors[i] % COLORS.length];
             final String s = " " + el.toString() + " ";
             widths.add(s.length());
-            arrSj.add(s);
+            arrSj.add(colorize(s, color));
         }
 
         final StringJoiner sj = new StringJoiner("\n");


### PR DESCRIPTION
This PR adds an option to print arrays with colored fields. This could be useful for some sort algorithms to specify stepwidths, sub fields or special elements.

![image](https://user-images.githubusercontent.com/3965334/121934392-8acd1400-cd47-11eb-88f5-9ed58c1203d6.png)
