### PR TITLE
Add Floyd-Warshall implementation (#19)

### DIFF
--- a/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
@@ -4,8 +4,12 @@ import com.github.cbl.algorithm_analyzer.contracts.Algorithm;
 import com.github.cbl.algorithm_analyzer.contracts.Event;
 import com.github.cbl.algorithm_analyzer.contracts.EventConsumer;
 import com.github.cbl.algorithm_analyzer.contracts.Graph;
+import com.github.cbl.algorithm_analyzer.contracts.WeightFreeGraph;
 import com.github.cbl.algorithm_analyzer.graphs.AdjacentMatrixGraph;
+import com.github.cbl.algorithm_analyzer.graphs.LinkedGraph;
+import com.github.cbl.algorithm_analyzer.graphs.LinkedGraph.Edge;
 import com.github.cbl.algorithm_analyzer.graphs.deepsearch.Deepsearch;
+import com.github.cbl.algorithm_analyzer.graphs.floydwarshall.FloydWarshall;
 import com.github.cbl.algorithm_analyzer.sorts.bubblesort.BubbleSort;
 import com.github.cbl.algorithm_analyzer.sorts.quicksort.Quicksort;
 import com.github.cbl.algorithm_analyzer.sorts.shellsort.Shellsort;
@@ -14,6 +18,7 @@ import com.github.cbl.algorithm_analyzer.util.GeneralEventConsumer;
 import com.github.cbl.algorithm_analyzer.util.LogEventVisitor;
 
 import java.util.Comparator;
+import java.util.Set;
 
 public class Main {
     public static void main(String[] args) throws Exception {
@@ -23,7 +28,7 @@ public class Main {
     public static void tiefenSuche() {
         int size = 4;
         String[] nodeNames = {"A", "B", "C", "D"};
-        Graph<Integer, boolean[][]> graph = new AdjacentMatrixGraph(size);
+        WeightFreeGraph<Integer> graph = new AdjacentMatrixGraph(size);
 
         graph.setEdge(0, 3);
         graph.setEdge(0, 2);
@@ -88,6 +93,26 @@ public class Main {
         t.remove(2);
         t.insert(13);
         t.remove(3);
+
+        ec.visitEvents(new LogEventVisitor());
+    }
+
+
+
+
+    @SuppressWarnings("varargs")
+    public static void floydWarshall() {
+        Graph<Character,Integer> costs = new LinkedGraph<>(Set.of(
+            Edge.of('v', 'x', 2),
+            Edge.of('w', 'v', 10),
+            Edge.of('w', 'x', 5),
+            Edge.of('x', 'v', 3),
+            Edge.of('x', 'y', 2),
+            Edge.of('y', 'v', 10),
+            Edge.of('y', 'w', 1)));
+        Algorithm<Event,FloydWarshall.Data<Character>> alg = new FloydWarshall<>();
+        final EventConsumer<Event> ec = new GeneralEventConsumer();
+        alg.run(ec, new FloydWarshall.Data<>(costs));
 
         ec.visitEvents(new LogEventVisitor());
     }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
@@ -97,20 +97,19 @@ public class Main {
         ec.visitEvents(new LogEventVisitor());
     }
 
-
-
-
     @SuppressWarnings("varargs")
     public static void floydWarshall() {
-        Graph<Character,Integer> costs = new LinkedGraph<>(Set.of(
-            Edge.of('v', 'x', 2),
-            Edge.of('w', 'v', 10),
-            Edge.of('w', 'x', 5),
-            Edge.of('x', 'v', 3),
-            Edge.of('x', 'y', 2),
-            Edge.of('y', 'v', 10),
-            Edge.of('y', 'w', 1)));
-        Algorithm<Event,FloydWarshall.Data<Character>> alg = new FloydWarshall<>();
+        Graph<Character, Integer> costs =
+                new LinkedGraph<>(
+                        Set.of(
+                                Edge.of('v', 'x', 2),
+                                Edge.of('w', 'v', 10),
+                                Edge.of('w', 'x', 5),
+                                Edge.of('x', 'v', 3),
+                                Edge.of('x', 'y', 2),
+                                Edge.of('y', 'v', 10),
+                                Edge.of('y', 'w', 1)));
+        Algorithm<Event, FloydWarshall.Data<Character>> alg = new FloydWarshall<>();
         final EventConsumer<Event> ec = new GeneralEventConsumer();
         alg.run(ec, new FloydWarshall.Data<>(costs));
 

--- a/src/main/java/com/github/cbl/algorithm_analyzer/contracts/Graph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/contracts/Graph.java
@@ -27,5 +27,5 @@ public interface Graph<V, E> extends Cloneable {
 
     void deleteEdge(V from, V to);
 
-    Graph<V,E> clone();
+    Graph<V, E> clone();
 }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/contracts/Graph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/contracts/Graph.java
@@ -1,18 +1,31 @@
 package com.github.cbl.algorithm_analyzer.contracts;
 
+import java.util.Collection;
+import java.util.Optional;
+
 /**
  * @param <V> type of vertices
  * @param <E> type of edge metadata (e.g. weight)
  */
-public interface Graph<V, E> {
+public interface Graph<V, E> extends Cloneable {
 
-    abstract boolean hasEdge(V from, V to);
+    class NoEdgeException extends Exception {}
 
-    abstract int getVerticeCount();
+    boolean hasEdge(V from, V to);
 
-    void setEdge(V from, V to);
+    default E getEdge(V from, V to) throws NoEdgeException {
+        return getEdgeMaybe(from, to).orElseThrow(NoEdgeException::new);
+    }
+
+    Optional<E> getEdgeMaybe(V from, V to);
+
+    int getVerticeCount();
+
+    Collection<V> getVertices();
+
+    void setEdge(V from, V to, E e);
 
     void deleteEdge(V from, V to);
 
-    E getEdges();
+    Graph<V,E> clone();
 }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/contracts/WeightFreeGraph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/contracts/WeightFreeGraph.java
@@ -1,0 +1,13 @@
+package com.github.cbl.algorithm_analyzer.contracts;
+
+/**
+ * @param <V> type of vertices
+ * @param <E> type of edge metadata (e.g. weight)
+ */
+public interface WeightFreeGraph<V> extends Graph<V,Boolean> {
+
+    default void setEdge(V from, V to) {
+        setEdge(from, to, true);
+    }
+
+}

--- a/src/main/java/com/github/cbl/algorithm_analyzer/contracts/WeightFreeGraph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/contracts/WeightFreeGraph.java
@@ -4,10 +4,9 @@ package com.github.cbl.algorithm_analyzer.contracts;
  * @param <V> type of vertices
  * @param <E> type of edge metadata (e.g. weight)
  */
-public interface WeightFreeGraph<V> extends Graph<V,Boolean> {
+public interface WeightFreeGraph<V> extends Graph<V, Boolean> {
 
     default void setEdge(V from, V to) {
         setEdge(from, to, true);
     }
-
 }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/AdjacentMatrixGraph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/AdjacentMatrixGraph.java
@@ -1,12 +1,18 @@
 package com.github.cbl.algorithm_analyzer.graphs;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
 import com.github.cbl.algorithm_analyzer.contracts.Graph;
+import com.github.cbl.algorithm_analyzer.contracts.WeightFreeGraph;
 
 /** Adjacent matrix based graph for int-vertices and no edge weight */
-public class AdjacentMatrixGraph implements Graph<Integer, boolean[][]> {
+public class AdjacentMatrixGraph implements WeightFreeGraph<Integer> {
 
-    private boolean[][] matrix;
-    private int verticeCount;
+    private final boolean[][] matrix;
+    private final int verticeCount;
 
     public AdjacentMatrixGraph(int verticeCount) {
         this.verticeCount = verticeCount;
@@ -16,9 +22,25 @@ public class AdjacentMatrixGraph implements Graph<Integer, boolean[][]> {
         }
     }
 
-    public void setEdge(Integer from, Integer to) {
+    private AdjacentMatrixGraph(int verticeCount, boolean[][] matrix) {
+        this.verticeCount = verticeCount;
+        this.matrix = matrix;
+    }
+
+    @Override
+    public Collection<Integer> getVertices() {
+        return Arrays.asList(IntStream.range(0, verticeCount).mapToObj(Integer::valueOf).toArray(Integer[]::new));
+    }
+
+    @Override
+    public Optional<Boolean> getEdgeMaybe(Integer from, Integer to) {
+        var e = matrix[from][to];
+        return Optional.ofNullable(e);
+    }
+
+    public void setEdge(Integer from, Integer to, Boolean weight) {
         if (from >= 0 && to >= 0 && from < verticeCount && to < verticeCount) {
-            matrix[from][to] = true;
+            matrix[from][to] = weight;
         }
     }
 
@@ -40,5 +62,14 @@ public class AdjacentMatrixGraph implements Graph<Integer, boolean[][]> {
 
     public boolean[][] getEdges() {
         return matrix;
+    }
+
+    @Override
+    public Graph<Integer,Boolean> clone() {
+        var matrixClone = matrix.clone();
+        for (int i = 0; i < matrix.length; i++) {
+            matrixClone[i] = matrixClone[i].clone();
+        }
+        return new AdjacentMatrixGraph(verticeCount, matrixClone);
     }
 }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/AdjacentMatrixGraph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/AdjacentMatrixGraph.java
@@ -1,12 +1,12 @@
 package com.github.cbl.algorithm_analyzer.graphs;
 
+import com.github.cbl.algorithm_analyzer.contracts.Graph;
+import com.github.cbl.algorithm_analyzer.contracts.WeightFreeGraph;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.IntStream;
-
-import com.github.cbl.algorithm_analyzer.contracts.Graph;
-import com.github.cbl.algorithm_analyzer.contracts.WeightFreeGraph;
 
 /** Adjacent matrix based graph for int-vertices and no edge weight */
 public class AdjacentMatrixGraph implements WeightFreeGraph<Integer> {
@@ -29,7 +29,10 @@ public class AdjacentMatrixGraph implements WeightFreeGraph<Integer> {
 
     @Override
     public Collection<Integer> getVertices() {
-        return Arrays.asList(IntStream.range(0, verticeCount).mapToObj(Integer::valueOf).toArray(Integer[]::new));
+        return Arrays.asList(
+                IntStream.range(0, verticeCount)
+                        .mapToObj(Integer::valueOf)
+                        .toArray(Integer[]::new));
     }
 
     @Override
@@ -65,7 +68,7 @@ public class AdjacentMatrixGraph implements WeightFreeGraph<Integer> {
     }
 
     @Override
-    public Graph<Integer,Boolean> clone() {
+    public Graph<Integer, Boolean> clone() {
         var matrixClone = matrix.clone();
         for (int i = 0; i < matrix.length; i++) {
             matrixClone[i] = matrixClone[i].clone();

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/LinkedGraph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/LinkedGraph.java
@@ -1,0 +1,79 @@
+package com.github.cbl.algorithm_analyzer.graphs;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.github.cbl.algorithm_analyzer.contracts.Graph;
+
+public class LinkedGraph<V,E> implements Graph<V,E> {
+
+    public record Edge<V,E>(V from, V to, E weight) {
+        public static <V,E> Edge<V,E> of(V a, V b, E e) {
+            return new Edge<>(a, b, e);
+        }
+
+        private Pair<V> toPair() {
+            return new Pair<>(from, to);
+        }
+    };
+
+    private record Pair<V>(V a, V b) {
+        static <V> Pair<V> of(V a, V b) {
+            return new Pair<>(a, b);
+        }
+    };
+
+    private final Map<Pair<V>,E> map;
+
+    public LinkedGraph() {
+        map = new HashMap<>();
+    }
+
+    public LinkedGraph(Collection<Edge<V,E>> edges) {
+        map = edges.stream().collect(Collectors.toMap(Edge::toPair, Edge::weight));
+    }
+
+    private LinkedGraph(Map<Pair<V>,E> map) {
+        this.map = map;
+    }
+
+    @Override
+    public Collection<V> getVertices() {
+        return map.keySet().stream().flatMap(p -> Stream.of(p.a, p.b)).distinct().toList();
+    }
+
+    @Override
+    public boolean hasEdge(V from, V to) {
+        return map.containsKey(Pair.of(from, to));
+    }
+
+    @Override
+    public Optional<E> getEdgeMaybe(V from, V to) {
+        return Optional.ofNullable(map.get(Pair.of(from, to)));
+    }
+
+    @Override
+    public int getVerticeCount() {
+        return (int) map.keySet().stream().flatMap(p -> Stream.of(p.a, p.b)).distinct().count();
+    }
+
+    @Override
+    public void setEdge(V from, V to, E e) {
+        map.put(Pair.of(from, to), e);
+    }
+
+    @Override
+    public void deleteEdge(V from, V to) {
+       map.remove(Pair.of(from, to));
+    }
+
+    @Override
+    public Graph<V,E> clone() {
+        return new LinkedGraph<>(new HashMap<>(map));
+    }
+    
+}

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/LinkedGraph.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/LinkedGraph.java
@@ -1,5 +1,7 @@
 package com.github.cbl.algorithm_analyzer.graphs;
 
+import com.github.cbl.algorithm_analyzer.contracts.Graph;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -7,37 +9,37 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.github.cbl.algorithm_analyzer.contracts.Graph;
+public class LinkedGraph<V, E> implements Graph<V, E> {
 
-public class LinkedGraph<V,E> implements Graph<V,E> {
-
-    public record Edge<V,E>(V from, V to, E weight) {
-        public static <V,E> Edge<V,E> of(V a, V b, E e) {
+    public record Edge<V, E>(V from, V to, E weight) {
+        public static <V, E> Edge<V, E> of(V a, V b, E e) {
             return new Edge<>(a, b, e);
         }
 
         private Pair<V> toPair() {
             return new Pair<>(from, to);
         }
-    };
+    }
+    ;
 
     private record Pair<V>(V a, V b) {
         static <V> Pair<V> of(V a, V b) {
             return new Pair<>(a, b);
         }
-    };
+    }
+    ;
 
-    private final Map<Pair<V>,E> map;
+    private final Map<Pair<V>, E> map;
 
     public LinkedGraph() {
         map = new HashMap<>();
     }
 
-    public LinkedGraph(Collection<Edge<V,E>> edges) {
+    public LinkedGraph(Collection<Edge<V, E>> edges) {
         map = edges.stream().collect(Collectors.toMap(Edge::toPair, Edge::weight));
     }
 
-    private LinkedGraph(Map<Pair<V>,E> map) {
+    private LinkedGraph(Map<Pair<V>, E> map) {
         this.map = map;
     }
 
@@ -68,12 +70,11 @@ public class LinkedGraph<V,E> implements Graph<V,E> {
 
     @Override
     public void deleteEdge(V from, V to) {
-       map.remove(Pair.of(from, to));
+        map.remove(Pair.of(from, to));
     }
 
     @Override
-    public Graph<V,E> clone() {
+    public Graph<V, E> clone() {
         return new LinkedGraph<>(new HashMap<>(map));
     }
-    
 }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/deepsearch/Deepsearch.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/deepsearch/Deepsearch.java
@@ -10,7 +10,7 @@ import java.util.StringJoiner;
 
 public class Deepsearch implements Algorithm<Event, Deepsearch.Data> {
 
-    public static record Data(Graph<Integer, boolean[][]> graph, String[] nodeNames) {}
+    public static record Data(Graph<Integer, ?> graph, String[] nodeNames) {}
     ;
 
     public static record FinalTimesEvent(
@@ -63,7 +63,7 @@ public class Deepsearch implements Algorithm<Event, Deepsearch.Data> {
     }
 
     public void run(EventConsumer<Event> events, Data data) {
-        Graph<Integer, boolean[][]> graph = data.graph();
+        Graph<Integer, ?> graph = data.graph();
         boolean known[] = new boolean[graph.getVerticeCount()];
         int previous[] = new int[graph.getVerticeCount()];
         int discovered[] = new int[graph.getVerticeCount()];
@@ -93,7 +93,7 @@ public class Deepsearch implements Algorithm<Event, Deepsearch.Data> {
     protected EdgeType getEdgeType(
             int from,
             int to,
-            Graph<Integer, boolean[][]> graph,
+            Graph<Integer, ?> graph,
             int[] discovered,
             int[] finished,
             int[] previous) {
@@ -118,7 +118,7 @@ public class Deepsearch implements Algorithm<Event, Deepsearch.Data> {
     }
 
     protected int expand(
-            Graph<Integer, boolean[][]> graph,
+            Graph<Integer, ?> graph,
             int u,
             int[] discovered,
             int[] finished,

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/floydwarshall/FloydWarshall.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/floydwarshall/FloydWarshall.java
@@ -1,0 +1,163 @@
+package com.github.cbl.algorithm_analyzer.graphs.floydwarshall;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import com.github.cbl.algorithm_analyzer.contracts.Algorithm;
+import com.github.cbl.algorithm_analyzer.contracts.Event;
+import com.github.cbl.algorithm_analyzer.contracts.EventConsumer;
+import com.github.cbl.algorithm_analyzer.contracts.Graph;
+import com.github.cbl.algorithm_analyzer.contracts.Graph.NoEdgeException;
+import com.github.cbl.algorithm_analyzer.graphs.LinkedGraph;
+import com.github.cbl.algorithm_analyzer.util.TablePrinter;
+
+/**
+ * Calculates all shortest path between all node pairs of a weighted graph
+ */
+public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>> {
+
+    public record Data<V>(Graph<V,Integer> costs) {}
+
+    record PartialDistancesEvent<V>(Graph<V,Distance<V>> distances, Collection<V> nodes) implements Event {
+        @Override
+        public String toString() {
+            try {
+                // convert distances graph to (string)[][] in order to print as table
+                var vn = distances.getVerticeCount();
+                var vs = StreamSupport.stream(distances.getVertices().spliterator(), false).toList();
+                String[][] ss = new String[vn + 1][vn + 1];
+                ss[0][0] = "";
+                for (int i = 0; i < vn; i++) {
+                    ss[0][i + 1] = vs.get(i).toString();
+                    ss[i + 1][0] = vs.get(i).toString();
+                }
+                for (int i = 0; i < vn; i++) {
+                    for (int j = 0; j < vn; j++) {
+                            ss[i + 1][j + 1] = distances.getEdge(vs.get(i), (V) vs.get(j)).toString();
+                    }
+                }
+                return "Nodes: " + nodes.toString() + "\n" + TablePrinter.toString(ss);
+            } catch (NoEdgeException e) {
+                e.printStackTrace();
+                return "Error: table of distances if only partially filled";
+            }
+        }
+    }
+
+    record PathEvent<V>(List<V> path, V from, V to) implements Event {
+        @Override
+        public String toString() {
+            return "Shorted path from " + from + " to " + to + " is over: " + path.toString();
+        }
+    }
+
+    /**
+     * Current distance between to nodes and the (optional) node over which the path leads
+     */
+    private record Distance<V>(Integer distance, V over) implements Comparable<Distance<V>> {
+
+        static <V> Distance<V> infinite() {
+            return new Distance<>(null, null);
+        }
+
+        Distance<V> add(Distance<V> other) {
+            if (null == this.distance || null == other.distance) {
+                return Distance.infinite();
+            } else {
+                return new Distance<>(this.distance + other.distance, null);
+            }
+        }
+
+        @Override
+        public String toString() {
+            if (null == distance) {
+                return "-";
+            } else if (null == over) {
+                return distance.toString();
+            } else {
+                return distance + ":" + over;
+            }
+        }
+
+        @Override
+        public int compareTo(Distance<V> o) {
+            if (null == this.distance) {
+                if (null == o.distance) {
+                    return 0;
+                } else {
+                    return 1;
+                }
+            } else {
+                if (null == o.distance) {
+                    return -1;
+                } else {
+                    return this.distance - o.distance;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void run(EventConsumer<Event> events, Data<V> data) {
+        final Graph<V, Distance<V>> distances = new LinkedGraph<>();
+        for (V i : data.costs.getVertices()) {
+            for (V j : data.costs.getVertices()) {
+                if (i.equals(j)) {
+                    distances.setEdge(i, j, new Distance<>(0, null));
+                } else {
+                    distances.setEdge(i, j, data.costs.getEdgeMaybe(i, j).map(cost -> new Distance<V>(cost, null)).orElseGet(Distance::infinite)); 
+                }
+            }
+        }
+
+        events.accept(new PartialDistancesEvent<>(distances.clone(), Set.of()));
+
+        try {
+            Set<V> nodes = new HashSet<>();
+            for (V k : data.costs.getVertices()) {
+                nodes.add(k);
+                for (V i : data.costs.getVertices()) {
+                    for (V j : data.costs.getVertices()) {
+                        var d = distances.getEdge(i, j);
+                        var dk = distances.getEdge(i, k).add(distances.getEdge(k, j));
+                        if (dk.compareTo(d) < 0) {
+                            distances.setEdge(i, j, new Distance<>(dk.distance, k));
+
+                        }
+                    }
+                }
+
+                events.accept(new PartialDistancesEvent<>(distances.clone(), new HashSet<>(nodes)));
+            }
+
+            for (V i : data.costs.getVertices()) {
+                for (V j : data.costs.getVertices()) {
+                    if (!i.equals(j)) {
+                        var p = path(distances, i, j);
+                        events.accept(new PathEvent<>(p, i, j));
+                    }
+                }
+            }
+        } catch (NoEdgeException e) {
+            e.printStackTrace();
+            assert (false); // should never happen. If the distances graph misses some edges there is a conceptional error, no runtime error 
+        }
+    }
+
+    private List<V> path(Graph<V, Distance<V>> distances, V from, V to) throws NoEdgeException {
+        var d = distances.getEdge(from, to);
+        if (null == d.over) {
+            return List.of();
+        } else {
+            var a = path(distances, from, d.over);
+            var b = path(distances, d.over, to);
+
+            return Stream.concat(Stream.concat(a.stream(), Stream.of(d.over)), b.stream()).toList();
+        }
+    }
+    
+}

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/floydwarshall/FloydWarshall.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/floydwarshall/FloydWarshall.java
@@ -1,12 +1,5 @@
 package com.github.cbl.algorithm_analyzer.graphs.floydwarshall;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
 import com.github.cbl.algorithm_analyzer.contracts.Algorithm;
 import com.github.cbl.algorithm_analyzer.contracts.Event;
 import com.github.cbl.algorithm_analyzer.contracts.EventConsumer;
@@ -15,20 +8,27 @@ import com.github.cbl.algorithm_analyzer.contracts.Graph.NoEdgeException;
 import com.github.cbl.algorithm_analyzer.graphs.LinkedGraph;
 import com.github.cbl.algorithm_analyzer.util.TablePrinter;
 
-/**
- * Calculates all shortest path between all node pairs of a weighted graph
- */
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/** Calculates all shortest path between all node pairs of a weighted graph */
 public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>> {
 
-    public record Data<V>(Graph<V,Integer> costs) {}
+    public record Data<V>(Graph<V, Integer> costs) {}
 
-    record PartialDistancesEvent<V>(Graph<V,Distance<V>> distances, Collection<V> nodes) implements Event {
+    record PartialDistancesEvent<V>(Graph<V, Distance<V>> distances, Collection<V> nodes)
+            implements Event {
         @Override
         public String toString() {
             try {
                 // convert distances graph to (string)[][] in order to print as table
                 var vn = distances.getVerticeCount();
-                var vs = StreamSupport.stream(distances.getVertices().spliterator(), false).toList();
+                var vs =
+                        StreamSupport.stream(distances.getVertices().spliterator(), false).toList();
                 String[][] ss = new String[vn + 1][vn + 1];
                 ss[0][0] = "";
                 for (int i = 0; i < vn; i++) {
@@ -37,7 +37,7 @@ public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>>
                 }
                 for (int i = 0; i < vn; i++) {
                     for (int j = 0; j < vn; j++) {
-                            ss[i + 1][j + 1] = distances.getEdge(vs.get(i), (V) vs.get(j)).toString();
+                        ss[i + 1][j + 1] = distances.getEdge(vs.get(i), (V) vs.get(j)).toString();
                     }
                 }
                 return "Nodes: " + nodes.toString() + "\n" + TablePrinter.toString(ss);
@@ -55,9 +55,7 @@ public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>>
         }
     }
 
-    /**
-     * Current distance between to nodes and the (optional) node over which the path leads
-     */
+    /** Current distance between to nodes and the (optional) node over which the path leads */
     private record Distance<V>(Integer distance, V over) implements Comparable<Distance<V>> {
 
         static <V> Distance<V> infinite() {
@@ -109,7 +107,13 @@ public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>>
                 if (i.equals(j)) {
                     distances.setEdge(i, j, new Distance<>(0, null));
                 } else {
-                    distances.setEdge(i, j, data.costs.getEdgeMaybe(i, j).map(cost -> new Distance<V>(cost, null)).orElseGet(Distance::infinite)); 
+                    distances.setEdge(
+                            i,
+                            j,
+                            data.costs
+                                    .getEdgeMaybe(i, j)
+                                    .map(cost -> new Distance<V>(cost, null))
+                                    .orElseGet(Distance::infinite));
                 }
             }
         }
@@ -126,7 +130,6 @@ public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>>
                         var dk = distances.getEdge(i, k).add(distances.getEdge(k, j));
                         if (dk.compareTo(d) < 0) {
                             distances.setEdge(i, j, new Distance<>(dk.distance, k));
-
                         }
                     }
                 }
@@ -144,7 +147,8 @@ public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>>
             }
         } catch (NoEdgeException e) {
             e.printStackTrace();
-            assert (false); // should never happen. If the distances graph misses some edges there is a conceptional error, no runtime error 
+            assert (false); // should never happen. If the distances graph misses some edges there
+                            // is a conceptional error, no runtime error
         }
     }
 
@@ -159,5 +163,4 @@ public class FloydWarshall<V> implements Algorithm<Event, FloydWarshall.Data<V>>
             return Stream.concat(Stream.concat(a.stream(), Stream.of(d.over)), b.stream()).toList();
         }
     }
-    
 }


### PR DESCRIPTION
This PR adds an implementation of the 'Floyd-Warshall' algorithm, calculating shortest paths for all node-pairs of a given graph.

![image](https://user-images.githubusercontent.com/3965334/122047707-bbad5780-cde0-11eb-9757-eb503bb225ed.png)
