### PR TITLE
straight-mergesort

### DIFF
--- a/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
@@ -15,6 +15,7 @@ import com.github.cbl.algorithm_analyzer.sorts.bubblesort.BubbleSort;
 import com.github.cbl.algorithm_analyzer.sorts.heapsort.HeapSort;
 import com.github.cbl.algorithm_analyzer.sorts.quicksort.Quicksort;
 import com.github.cbl.algorithm_analyzer.sorts.shellsort.Shellsort;
+import com.github.cbl.algorithm_analyzer.sorts.straightmergesort.StraightMergesort;
 import com.github.cbl.algorithm_analyzer.trees.AvlTree.AVLTree;
 import com.github.cbl.algorithm_analyzer.util.GeneralEventConsumer;
 import com.github.cbl.algorithm_analyzer.util.LogEventVisitor;
@@ -24,7 +25,7 @@ import java.util.Set;
 
 public class Main {
     public static void main(String[] args) throws Exception {
-        Main.dijkstra();
+        Main.straightMergesort();
     }
 
     public static void dijkstra() {
@@ -106,6 +107,17 @@ public class Main {
         final EventConsumer<Event> ec = new GeneralEventConsumer();
 
         a.run(ec, new HeapSort.Data<>(array));
+
+        ec.visitEvents(new LogEventVisitor());
+    }
+
+    public static void straightMergesort() {
+        final Integer[] array = {20, 54, 28, 31, 5, 24, 39, 14, 1, 15};
+
+        final Algorithm<Event, StraightMergesort.Data<Integer>> a = new StraightMergesort<Integer>();
+        final EventConsumer<Event> ec = new GeneralEventConsumer();
+
+        a.run(ec, new StraightMergesort.Data<>(array));
 
         ec.visitEvents(new LogEventVisitor());
     }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
@@ -114,7 +114,8 @@ public class Main {
     public static void straightMergesort() {
         final Integer[] array = {20, 54, 28, 31, 5, 24, 39, 14, 1, 15};
 
-        final Algorithm<Event, StraightMergesort.Data<Integer>> a = new StraightMergesort<Integer>();
+        final Algorithm<Event, StraightMergesort.Data<Integer>> a =
+                new StraightMergesort<Integer>();
         final EventConsumer<Event> ec = new GeneralEventConsumer();
 
         a.run(ec, new StraightMergesort.Data<>(array));

--- a/src/main/java/com/github/cbl/algorithm_analyzer/sorts/straightmergesort/StraightMergesort.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/sorts/straightmergesort/StraightMergesort.java
@@ -9,7 +9,8 @@ import com.github.cbl.algorithm_analyzer.util.Comparator;
 
 import java.util.StringJoiner;
 
-public class StraightMergesort<T extends Comparable<T>> implements Algorithm<Event, StraightMergesort.Data<T>> {
+public class StraightMergesort<T extends Comparable<T>>
+        implements Algorithm<Event, StraightMergesort.Data<T>> {
 
     public static record Data<T extends Comparable<T>>(T[] array) {}
 
@@ -73,22 +74,29 @@ public class StraightMergesort<T extends Comparable<T>> implements Algorithm<Eve
         final ArrayWriter w = new ArrayWriter();
 
         int sortlength = 1;
-        int n = arr.length-1;
+        int n = arr.length - 1;
 
-        while(sortlength < n){
+        while (sortlength < n) {
             int right = -1;
-            while(right + sortlength < n){
+            while (right + sortlength < n) {
                 int left = right + 1;
                 int middle = left + sortlength - 1;
-                if(middle + sortlength <= n){
+                if (middle + sortlength <= n) {
                     right = middle + sortlength;
-                }
-                else{
+                } else {
                     right = n;
                 }
-                events.accept(new PartialStateEvent<T>(arr.clone(), left, middle, right, "Array A:"));
+                events.accept(
+                        new PartialStateEvent<T>(arr.clone(), left, middle, right, "Array A:"));
                 merge(arr, left, middle, right, c, w, events);
-                events.accept(new FinalStateEvent<T>(arr.clone(), left, right, right, c.getComparisonsSnapshot(), w.getWritesSnapshot()));
+                events.accept(
+                        new FinalStateEvent<T>(
+                                arr.clone(),
+                                left,
+                                right,
+                                right,
+                                c.getComparisonsSnapshot(),
+                                w.getWritesSnapshot()));
             }
             sortlength = 2 * sortlength;
         }
@@ -97,43 +105,43 @@ public class StraightMergesort<T extends Comparable<T>> implements Algorithm<Eve
     ;
 
     public void merge(
-        T[] arrA,
-        int left,
-        int middle,
-        int right,
-        Comparator c,
-        ArrayWriter w,
-        EventConsumer<Event> events) {
-    T[] arrB = arrA.clone();
+            T[] arrA,
+            int left,
+            int middle,
+            int right,
+            Comparator c,
+            ArrayWriter w,
+            EventConsumer<Event> events) {
+        T[] arrB = arrA.clone();
 
-    for (int j = 0; j < arrB.length; j++) {
-        arrB[j] = null;
-    }
-
-    for (int i = left; i <= middle; i++) {
-        w.set(arrB, i, arrA[i]);
-    }
-
-    for (int j = middle + 1; j <= right; j++) {
-        w.set(arrB, right + middle + 1 - j, arrA[j]);
-    }
-
-    events.accept(new PartialStateEvent<T>(arrB.clone(), 0, 0, 0, "Array B:"));
-
-    int i = left;
-    int j = right;
-    int k = left;
-
-    while (i < j) {
-        if (c.compare(arrB[i], arrB[j]) <= 0) {
-            w.set(arrA, k, arrB[i]);
-            i++;
-        } else {
-            w.set(arrA, k, arrB[j]);
-            j--;
+        for (int j = 0; j < arrB.length; j++) {
+            arrB[j] = null;
         }
-        k++;
-    }
-    w.set(arrA, right, arrB[i]);
-}}
 
+        for (int i = left; i <= middle; i++) {
+            w.set(arrB, i, arrA[i]);
+        }
+
+        for (int j = middle + 1; j <= right; j++) {
+            w.set(arrB, right + middle + 1 - j, arrA[j]);
+        }
+
+        events.accept(new PartialStateEvent<T>(arrB.clone(), 0, 0, 0, "Array B:"));
+
+        int i = left;
+        int j = right;
+        int k = left;
+
+        while (i < j) {
+            if (c.compare(arrB[i], arrB[j]) <= 0) {
+                w.set(arrA, k, arrB[i]);
+                i++;
+            } else {
+                w.set(arrA, k, arrB[j]);
+                j--;
+            }
+            k++;
+        }
+        w.set(arrA, right, arrB[i]);
+    }
+}

--- a/src/main/java/com/github/cbl/algorithm_analyzer/sorts/straightmergesort/StraightMergesort.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/sorts/straightmergesort/StraightMergesort.java
@@ -1,0 +1,139 @@
+package com.github.cbl.algorithm_analyzer.sorts.straightmergesort;
+
+import com.github.cbl.algorithm_analyzer.contracts.Algorithm;
+import com.github.cbl.algorithm_analyzer.contracts.Event;
+import com.github.cbl.algorithm_analyzer.contracts.EventConsumer;
+import com.github.cbl.algorithm_analyzer.util.ArrayPrinter;
+import com.github.cbl.algorithm_analyzer.util.ArrayWriter;
+import com.github.cbl.algorithm_analyzer.util.Comparator;
+
+import java.util.StringJoiner;
+
+public class StraightMergesort<T extends Comparable<T>> implements Algorithm<Event, StraightMergesort.Data<T>> {
+
+    public static record Data<T extends Comparable<T>>(T[] array) {}
+
+    public static record PartialStateEvent<T>(T[] arr, int left, int middle, int right, String text)
+            implements Event {
+        @Override
+        public String toString() {
+            final StringJoiner sj = new StringJoiner("\n");
+            if (text != null) {
+                sj.add(text);
+            }
+            int[] colors = new int[arr.length];
+            for (int i = 0; i < arr.length; i++) {
+                colors[i] = -1;
+            }
+            if (left != middle || middle != right) {
+                for (int i = left; i <= middle; i++) {
+                    colors[i] = 1;
+                }
+                for (int i = middle + 1; i <= right; i++) {
+                    colors[i] = 2;
+                }
+            }
+            sj.add(ArrayPrinter.toString(arr, colors));
+            return sj.toString();
+        }
+    }
+
+    public static record FinalStateEvent<T>(
+            T[] arr, int left, int middle, int right, long comparisons, long writes)
+            implements Event {
+        @Override
+        public String toString() {
+            final StringJoiner sj = new StringJoiner("\n");
+            sj.add("Array A after sorting and merging:");
+            int[] colors = new int[arr.length];
+            for (int i = 0; i < arr.length; i++) {
+                colors[i] = -1;
+            }
+            if (left != middle || middle != right) {
+                for (int i = left; i <= middle; i++) {
+                    colors[i] = 1;
+                }
+                for (int i = middle + 1; i <= right; i++) {
+                    colors[i] = 2;
+                }
+            }
+            sj.add(ArrayPrinter.toString(arr, colors));
+            sj.add("Comparisons: " + comparisons);
+            sj.add("Writes: " + writes);
+            sj.add("\n\n\n");
+
+            return sj.toString();
+        }
+    }
+
+    @Override
+    public void run(EventConsumer<Event> events, Data<T> data) {
+        final T[] arr = data.array();
+        final Comparator c = new Comparator();
+        final ArrayWriter w = new ArrayWriter();
+
+        int sortlength = 1;
+        int n = arr.length-1;
+
+        while(sortlength < n){
+            int right = -1;
+            while(right + sortlength < n){
+                int left = right + 1;
+                int middle = left + sortlength - 1;
+                if(middle + sortlength <= n){
+                    right = middle + sortlength;
+                }
+                else{
+                    right = n;
+                }
+                events.accept(new PartialStateEvent<T>(arr.clone(), left, middle, right, "Array A:"));
+                merge(arr, left, middle, right, c, w, events);
+                events.accept(new FinalStateEvent<T>(arr.clone(), left, right, right, c.getComparisonsSnapshot(), w.getWritesSnapshot()));
+            }
+            sortlength = 2 * sortlength;
+        }
+        events.accept(new FinalStateEvent<T>(arr, 0, 0, 0, c.getComparisons(), w.getWrites()));
+    }
+    ;
+
+    public void merge(
+        T[] arrA,
+        int left,
+        int middle,
+        int right,
+        Comparator c,
+        ArrayWriter w,
+        EventConsumer<Event> events) {
+    T[] arrB = arrA.clone();
+
+    for (int j = 0; j < arrB.length; j++) {
+        arrB[j] = null;
+    }
+
+    for (int i = left; i <= middle; i++) {
+        w.set(arrB, i, arrA[i]);
+    }
+
+    for (int j = middle + 1; j <= right; j++) {
+        w.set(arrB, right + middle + 1 - j, arrA[j]);
+    }
+
+    events.accept(new PartialStateEvent<T>(arrB.clone(), 0, 0, 0, "Array B:"));
+
+    int i = left;
+    int j = right;
+    int k = left;
+
+    while (i < j) {
+        if (c.compare(arrB[i], arrB[j]) <= 0) {
+            w.set(arrA, k, arrB[i]);
+            i++;
+        } else {
+            w.set(arrA, k, arrB[j]);
+            j--;
+        }
+        k++;
+    }
+    w.set(arrA, right, arrB[i]);
+}}
+

--- a/src/main/java/com/github/cbl/algorithm_analyzer/util/ArrayPrinter.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/util/ArrayPrinter.java
@@ -53,6 +53,11 @@ public class ArrayPrinter {
         final StringJoiner arrSj = new StringJoiner("|", "|", "|");
         for (int i = 0; i < arr.length; i++) {
             Object el = arr[i];
+            if (el == null) {
+                el = "";
+            } else {
+                el = arr[i];
+            }
             var color = i >= colors.length ? new Attribute[] {} : getColor(colors[i]);
             final String s = " " + el.toString() + " ";
             widths.add(s.length());


### PR DESCRIPTION
I've implemented straight-mergesort. I copied the function `merge` from the "normal" mergesort, because I didn't want to wait until we merge the other feat. If you prefer the other option, we first have to merge the branches. I also added the same changes in the `ArrayPrinter` as I did in the `feat/mergesort`.
![Bildschirmfoto 2021-07-26 um 09 17 33](https://user-images.githubusercontent.com/73591771/126948376-2b70c361-e974-408a-a44a-eeb466bd16df.png)
![Bildschirmfoto 2021-07-26 um 09 17 46](https://user-images.githubusercontent.com/73591771/126948405-b0a07fd7-0b4d-4dbf-ab88-cd0e9f28f80d.png)
