### PR TITLE
quicksort: add colored output

### DIFF
--- a/src/main/java/com/github/cbl/algorithm_analyzer/sorts/quicksort/Quicksort.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/sorts/quicksort/Quicksort.java
@@ -7,6 +7,7 @@ import com.github.cbl.algorithm_analyzer.util.ArrayPrinter;
 import com.github.cbl.algorithm_analyzer.util.ArrayWriter;
 import com.github.cbl.algorithm_analyzer.util.Comparator;
 
+import java.util.Arrays;
 import java.util.StringJoiner;
 
 public class Quicksort<T extends Comparable<T>> implements Algorithm<Event, Quicksort.Data<T>> {
@@ -31,7 +32,15 @@ public class Quicksort<T extends Comparable<T>> implements Algorithm<Event, Quic
         @Override
         public String toString() {
             final StringJoiner sj = new StringJoiner("\n");
-            sj.add(ArrayPrinter.toString(array));
+
+            int[] colors = new int[array.length];
+            Arrays.fill(colors, -1);
+
+            for (int i = range.p; i <= range.q; i++) {
+                colors[i] = 1; // range -> green
+            }
+
+            sj.add(ArrayPrinter.toString(array, colors));
             sj.add("Comparisons: " + comparisons);
             sj.add("Writes: " + writes);
             sj.add("Partition range: [" + (range.p + 1) + "-" + (range.q + 1) + "]");

--- a/src/main/java/com/github/cbl/algorithm_analyzer/sorts/quicksort/Quicksort.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/sorts/quicksort/Quicksort.java
@@ -36,9 +36,11 @@ public class Quicksort<T extends Comparable<T>> implements Algorithm<Event, Quic
             int[] colors = new int[array.length];
             Arrays.fill(colors, -1);
 
-            for (int i = range.p; i <= range.q; i++) {
+            for (int i = range.p; i < range.q; i++) {
                 colors[i] = 1; // range -> green
             }
+
+            colors[range.q] = 2; // pivot -> yellow
 
             sj.add(ArrayPrinter.toString(array, colors));
             sj.add("Comparisons: " + comparisons);
@@ -64,14 +66,14 @@ public class Quicksort<T extends Comparable<T>> implements Algorithm<Event, Quic
     private void quicksort(
             T[] arr, int i, int j, Comparator c, ArrayWriter w, EventConsumer<Event> events) {
         if (i < j) {
-            var range = partition(arr, i, j, c, w, events);
-
             events.accept(
                     new PartialStateEvent<>(
                             arr.clone(),
                             new Range(i, j),
                             c.getComparisonsSnapshot(),
                             w.getWritesSnapshot()));
+
+            var range = partition(arr, i, j, c, w, events);
 
             quicksort(arr, i, range.p, c, w, events);
             quicksort(arr, range.q, j, c, w, events);

--- a/src/main/java/com/github/cbl/algorithm_analyzer/util/ArrayPrinter.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/util/ArrayPrinter.java
@@ -12,21 +12,21 @@ import java.util.StringJoiner;
 /** Utility class for pretty-printing arrays */
 public class ArrayPrinter {
 
-    private static final Attribute[][] COLORS = {
+    private static final Attribute[][] COLORS = { // reference for ANSI 8 bit color codes: https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
         {
-            BLACK_TEXT(), BACK_COLOR(196),
+            BLACK_TEXT(), BACK_COLOR(196), // 0 = red
         },
         {
-            BLACK_TEXT(), BACK_COLOR(82),
+            BLACK_TEXT(), BACK_COLOR(82),  // 1 = green
         },
         {
-            BLACK_TEXT(), BACK_COLOR(226),
+            BLACK_TEXT(), BACK_COLOR(226), // 2 = yellow
         },
         {
-            BLACK_TEXT(), BACK_COLOR(208),
+            BLACK_TEXT(), BACK_COLOR(208), // 3 = orange
         },
         {
-            BLACK_TEXT(), BACK_COLOR(165),
+            BLACK_TEXT(), BACK_COLOR(165), // 4 = purple
         },
     };
 


### PR DESCRIPTION

This merge request adds colored output to quicksort.

The change in 42fa4fc  is probably debatable as I've changed when a `PartialStateEvent` is captured. Now the event is captured before partitioning as this way the pivot element can be highlighted and the output is similar as if you would do it by hand on a piece of paper.

![Screenshot 2021-07-26 134656](https://user-images.githubusercontent.com/6502589/126983838-6daef674-e932-42e3-ad5b-96f5b8acec00.png)