### PR TITLE
Add breath first (breitensuche) implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,28 @@ ec.visitEvents(new LogEventVisitor());
 ### Breath-First Search (Breitensuche)
 
 ```java
-// Todo ...
+String start = "v1";
+Collection<Edge<String, Integer>> edges = Set.of(
+    Edge.of("v1", "v2", 7),
+    Edge.of("v1", "v3", 4),
+    Edge.of("v1", "v4", 2),
+    Edge.of("v2", "v3", 3),
+    Edge.of("v2", "v5", 3),
+    Edge.of("v3", "v4", 1),
+    Edge.of("v3", "v5", 5),
+    Edge.of("v4", "v5", 8)
+);
+Graph<String, Integer> graph = new LinkedGraph<>(edges);
+for (Edge<String, Integer> e : edges) {
+    graph.setEdge(e.to(), e.from(), e.weight());
+}
+
+final Algorithm<Event, BreathFirst.Data> a = new BreathFirst();
+final EventConsumer<Event> ec = new GeneralEventConsumer();
+
+a.run(ec, new BreathFirst.Data<String>(graph, start));
+
+ec.visitEvents(new LogEventVisitor());
 ```
 
 <a name="dijkstra"></a>

--- a/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
@@ -238,19 +238,18 @@ public class Main {
         ec.visitEvents(new LogEventVisitor());
     }
 
-    public static void breathFirst()
-    {
+    public static void breathFirst() {
         String start = "v1";
-        Collection<Edge<String, Integer>> edges = Set.of(
-            Edge.of("v1", "v2", 7),
-            Edge.of("v1", "v3", 4),
-            Edge.of("v1", "v4", 2),
-            Edge.of("v2", "v3", 3),
-            Edge.of("v2", "v5", 3),
-            Edge.of("v3", "v4", 1),
-            Edge.of("v3", "v5", 5),
-            Edge.of("v4", "v5", 8)
-        );
+        Collection<Edge<String, Integer>> edges =
+                Set.of(
+                        Edge.of("v1", "v2", 7),
+                        Edge.of("v1", "v3", 4),
+                        Edge.of("v1", "v4", 2),
+                        Edge.of("v2", "v3", 3),
+                        Edge.of("v2", "v5", 3),
+                        Edge.of("v3", "v4", 1),
+                        Edge.of("v3", "v5", 5),
+                        Edge.of("v4", "v5", 8));
         Graph<String, Integer> graph = new LinkedGraph<>(edges);
         for (Edge<String, Integer> e : edges) {
             graph.setEdge(e.to(), e.from(), e.weight());

--- a/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/Main.java
@@ -8,6 +8,7 @@ import com.github.cbl.algorithm_analyzer.contracts.WeightFreeGraph;
 import com.github.cbl.algorithm_analyzer.graphs.AdjacentMatrixGraph;
 import com.github.cbl.algorithm_analyzer.graphs.LinkedGraph;
 import com.github.cbl.algorithm_analyzer.graphs.LinkedGraph.Edge;
+import com.github.cbl.algorithm_analyzer.graphs.breath_first.BreathFirst;
 import com.github.cbl.algorithm_analyzer.graphs.deepsearch.Deepsearch;
 import com.github.cbl.algorithm_analyzer.graphs.dijkstra.Dijkstra;
 import com.github.cbl.algorithm_analyzer.graphs.floydwarshall.FloydWarshall;
@@ -41,7 +42,7 @@ import java.util.Set;
 
 public class Main {
     public static void main(String[] args) throws Exception {
-        Main.radixSort();
+        Main.breathFirst();
     }
 
     public static void sortedList() {
@@ -233,6 +234,32 @@ public class Main {
         final EventConsumer<Event> ec = new GeneralEventConsumer();
 
         a.run(ec, new Dijkstra.Data<Character>(costs, 'A'));
+
+        ec.visitEvents(new LogEventVisitor());
+    }
+
+    public static void breathFirst()
+    {
+        String start = "v1";
+        Collection<Edge<String, Integer>> edges = Set.of(
+            Edge.of("v1", "v2", 7),
+            Edge.of("v1", "v3", 4),
+            Edge.of("v1", "v4", 2),
+            Edge.of("v2", "v3", 3),
+            Edge.of("v2", "v5", 3),
+            Edge.of("v3", "v4", 1),
+            Edge.of("v3", "v5", 5),
+            Edge.of("v4", "v5", 8)
+        );
+        Graph<String, Integer> graph = new LinkedGraph<>(edges);
+        for (Edge<String, Integer> e : edges) {
+            graph.setEdge(e.to(), e.from(), e.weight());
+        }
+
+        final Algorithm<Event, BreathFirst.Data> a = new BreathFirst();
+        final EventConsumer<Event> ec = new GeneralEventConsumer();
+
+        a.run(ec, new BreathFirst.Data<String>(graph, start));
 
         ec.visitEvents(new LogEventVisitor());
     }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/breath_first/BreathFirst.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/breath_first/BreathFirst.java
@@ -7,11 +7,10 @@ import com.github.cbl.algorithm_analyzer.contracts.Graph;
 import com.github.cbl.algorithm_analyzer.contracts.Graph.NoEdgeException;
 import com.github.cbl.algorithm_analyzer.util.TablePrinter;
 
-import java.util.StringJoiner;
-import java.util.Map;
 import java.util.HashMap;
-import java.util.Queue;
 import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
 
 public class BreathFirst<V> implements Algorithm<Event, BreathFirst.Data<V>> {
 
@@ -20,8 +19,8 @@ public class BreathFirst<V> implements Algorithm<Event, BreathFirst.Data<V>> {
     public static record Data<V>(Graph<V, Integer> graph, V start) {}
     ;
 
-    public static record FinalTimesEvent<V>(
-            Graph<V, Integer> graph, State<V> state, V start) implements Event {
+    public static record FinalTimesEvent<V>(Graph<V, Integer> graph, State<V> state, V start)
+            implements Event {
         @Override
         public String toString() {
 
@@ -69,9 +68,9 @@ public class BreathFirst<V> implements Algorithm<Event, BreathFirst.Data<V>> {
         Graph<V, Integer> g = data.graph();
         V start = data.start();
         State<V> state = new State<V>();
-        
-        for(V u : g.getVertices()) {
-            if(u == start) continue;
+
+        for (V u : g.getVertices()) {
+            if (u == start) continue;
             state.isKnown.put(u, false);
             state.distance.put(u, INFINITY);
             state.previous.put(u, null);
@@ -84,12 +83,12 @@ public class BreathFirst<V> implements Algorithm<Event, BreathFirst.Data<V>> {
         q.add(start);
 
         try {
-            while(!q.isEmpty()) {
+            while (!q.isEmpty()) {
                 V u = q.poll();
-                for(V v : g.getVertices().stream().sorted().toList()) {
-                    if(!g.hasEdge(u, v)) continue;
-                    if(!state.isKnown.get(v)) {
-                        state.distance.put(v, state.distance.get(u)+g.getEdge(u, v));
+                for (V v : g.getVertices().stream().sorted().toList()) {
+                    if (!g.hasEdge(u, v)) continue;
+                    if (!state.isKnown.get(v)) {
+                        state.distance.put(v, state.distance.get(u) + g.getEdge(u, v));
                         state.previous.put(v, u);
                         state.isKnown.put(v, true);
                         q.add(v);
@@ -97,7 +96,7 @@ public class BreathFirst<V> implements Algorithm<Event, BreathFirst.Data<V>> {
                 }
             }
             events.accept(new FinalTimesEvent(g, state.clone(), start));
-        } catch(NoEdgeException e) {
+        } catch (NoEdgeException e) {
             System.out.println("Error: Missing edge");
         }
     }

--- a/src/main/java/com/github/cbl/algorithm_analyzer/graphs/breath_first/BreathFirst.java
+++ b/src/main/java/com/github/cbl/algorithm_analyzer/graphs/breath_first/BreathFirst.java
@@ -1,0 +1,104 @@
+package com.github.cbl.algorithm_analyzer.graphs.breath_first;
+
+import com.github.cbl.algorithm_analyzer.contracts.Algorithm;
+import com.github.cbl.algorithm_analyzer.contracts.Event;
+import com.github.cbl.algorithm_analyzer.contracts.EventConsumer;
+import com.github.cbl.algorithm_analyzer.contracts.Graph;
+import com.github.cbl.algorithm_analyzer.contracts.Graph.NoEdgeException;
+import com.github.cbl.algorithm_analyzer.util.TablePrinter;
+
+import java.util.StringJoiner;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Queue;
+import java.util.LinkedList;
+
+public class BreathFirst<V> implements Algorithm<Event, BreathFirst.Data<V>> {
+
+    private static final int INFINITY = Integer.MAX_VALUE;
+
+    public static record Data<V>(Graph<V, Integer> graph, V start) {}
+    ;
+
+    public static record FinalTimesEvent<V>(
+            Graph<V, Integer> graph, State<V> state, V start) implements Event {
+        @Override
+        public String toString() {
+
+            Object[][] table = new Object[4][];
+            table[0] = new Object[graph.getVerticeCount() + 1];
+            table[1] = new Object[graph.getVerticeCount() + 1];
+            table[2] = new Object[graph.getVerticeCount() + 1];
+            table[3] = new Object[graph.getVerticeCount() + 1];
+            table[0][0] = "";
+            table[1][0] = "Is known";
+            table[2][0] = "Distance";
+            table[3][0] = "Previous";
+
+            int i = 1;
+            for (V v : graph.getVertices().stream().sorted().toList()) {
+                table[0][i] = v.toString();
+                table[1][i] = state.isKnown.get(v);
+                table[2][i] = state.distance.get(v) == INFINITY ? "∞" : state.distance.get(v);
+                table[3][i] = state.previous.get(v);
+                i++;
+            }
+
+            return TablePrinter.toString(table);
+        }
+    }
+    ;
+
+    private record State<V>(Map<V, Boolean> isKnown, Map<V, Integer> distance, Map<V, V> previous)
+            implements Cloneable {
+
+        public State() {
+            this(new HashMap<V, Boolean>(), new HashMap<V, Integer>(), new HashMap<V, V>());
+        }
+
+        @Override
+        public State<V> clone() {
+            return new State<>(
+                    new HashMap<V, Boolean>(isKnown),
+                    new HashMap<V, Integer>(distance),
+                    new HashMap<V, V>(previous));
+        }
+    }
+
+    public void run(EventConsumer<Event> events, Data<V> data) {
+        Graph<V, Integer> g = data.graph();
+        V start = data.start();
+        State<V> state = new State<V>();
+        
+        for(V u : g.getVertices()) {
+            if(u == start) continue;
+            state.isKnown.put(u, false);
+            state.distance.put(u, INFINITY);
+            state.previous.put(u, null);
+        }
+
+        state.distance.put(start, 0);
+        state.isKnown.put(start, true);
+
+        Queue<V> q = new LinkedList<V>();
+        q.add(start);
+
+        try {
+            while(!q.isEmpty()) {
+                V u = q.poll();
+                for(V v : g.getVertices().stream().sorted().toList()) {
+                    if(!g.hasEdge(u, v)) continue;
+                    if(!state.isKnown.get(v)) {
+                        state.distance.put(v, state.distance.get(u)+g.getEdge(u, v));
+                        state.previous.put(v, u);
+                        state.isKnown.put(v, true);
+                        q.add(v);
+                    }
+                }
+            }
+            events.accept(new FinalTimesEvent(g, state.clone(), start));
+        } catch(NoEdgeException e) {
+            System.out.println("Error: Missing edge");
+        }
+    }
+}


### PR DESCRIPTION
<!--
Please only send a pull request to the "main" branch.

Specify a title that gives a short but clear indication of what was implemented in the pull request.

In addition, please describe how the implementation can be used.
-->
This pr adds the implementation for the breath first algorithm.

Usage:
```java
String start = "v1";
Collection<Edge<String, Integer>> edges = Set.of(
    Edge.of("v1", "v2", 7),
    Edge.of("v1", "v3", 4),
    Edge.of("v1", "v4", 2),
    Edge.of("v2", "v3", 3),
    Edge.of("v2", "v5", 3),
    Edge.of("v3", "v4", 1),
    Edge.of("v3", "v5", 5),
    Edge.of("v4", "v5", 8)
);
Graph<String, Integer> graph = new LinkedGraph<>(edges);
for (Edge<String, Integer> e : edges) {
    graph.setEdge(e.to(), e.from(), e.weight());
}

final Algorithm<Event, BreathFirst.Data> a = new BreathFirst();
final EventConsumer<Event> ec = new GeneralEventConsumer();

a.run(ec, new BreathFirst.Data<String>(graph, start));

ec.visitEvents(new LogEventVisitor());
```

<img width="332" alt="Bildschirmfoto 2021-07-27 um 16 06 36" src="https://user-images.githubusercontent.com/29352871/127168314-e487bb78-43f9-4d81-aee1-26700e4329dc.png">
